### PR TITLE
Fixing search query to use inverted index (filter needs search param)

### DIFF
--- a/govscentdotorg/views.py
+++ b/govscentdotorg/views.py
@@ -92,10 +92,10 @@ def topic_page(request, bill_topic_id):
 def topic_search_page(request):
     if request.method == 'POST':
         search_input = request.POST.get("searched")
-        vector = SearchVector("search_vector")
-        query = SearchQuery(search_input)
-        topics = BillTopic.objects.annotate(rank=SearchRank(vector, query))\
-            .filter(rank__gte=0.01)\
+        search_vector = SearchVector('search_vector', config='english')
+        search_query = SearchQuery(search_input)
+        topics = BillTopic.objects.annotate(rank=SearchRank(search_vector, search_query))\
+            .filter(search_vector=search_query, rank__gte=0.01)\
             .order_by('-rank')
         return render(request, 'topicSearch.html', {
             'searched': search_input,


### PR DESCRIPTION
Postgres wasn't using our fancy index, and instead doing a table scan. This causes the query planner to pick the index, by adding the search term in to the filter() call.