### PR TITLE
Fix topic parsing issue with showing scent score rather than the topic list

### DIFF
--- a/govscentdotorg/scripts/analyze_bills.py
+++ b/govscentdotorg/scripts/analyze_bills.py
@@ -75,10 +75,6 @@ def get_top_10_index(bill: Bill, response: str) -> (int, bool, bool):
     if index > -1:
         return index, False, False
 
-    index = response.find("Topic:")
-    if index > -1:
-        return index, True, False
-
     if response[:2] == "1.":
         return 0, False, False
 
@@ -89,6 +85,10 @@ def get_top_10_index(bill: Bill, response: str) -> (int, bool, bool):
     list_start_index = response.find('-')
     if list_start_index > -1:
         return list_start_index, False, False
+
+    index = response.find("Topic:")
+    if index > -1:
+        return index, True, False
 
     # In this case, probably just a raw list of topics by line.
     if len(bill.bill_sections.all()) > 1:


### PR DESCRIPTION
Issue:
when trying to parse the bill with gov_id 118s478is, bill id: 246343
The topic list start with **Topics:** rather than the **Top10**
And matches the last line instead of finding the topic list, as screenshot shown.
![Screenshot 2023-04-21134341](https://user-images.githubusercontent.com/14956712/233734190-7eaabb10-54a5-48a1-a4fc-b053e4c89031.png)

Debug: 
2 things need to be done:
1: sync the bill from prod, by running this command **./manage.py runscript sync_from_prod --script-args 1 246343**
Arguments: <optional_number_of_bills> <optional_bill_pk_id>, means number of bills and bill id
2: set up the configuration and bill's gov_id as the screenshots 

You can set the bill by gov_id as screenshot and only parse that bill
![Screenshot 2023-04-21135426](https://user-images.githubusercontent.com/14956712/233734472-d0dad6cb-3a76-428c-b90d-8f7cd7b445f4.png)
And set up the debug configuration like this:
![Screenshot 2023-04-21 140726](https://user-images.githubusercontent.com/14956712/233734860-549ddc05-5951-45eb-897a-f5d688aed0cf.png)




Fix:
Move the **Topic:** check after the index check